### PR TITLE
feat Add ability to configure the git directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ function getConfig() {
 
 function getGitFolder()
 {
-  var gitDirLocation = './.git';
+  var gitDirLocation = config.gitDirectory || './.git';
   if (!fs.existsSync(gitDirLocation)) {
       throw new Error('Cannot find file ' + gitDirLocation);
   }


### PR DESCRIPTION
feat add ability to configure the git directory

In the case of the modules and package.json files being in a child directory of the git repository this will allow a user to configure the location for the git directory that git hooks are managed in.

Example:

```
"validate-commit-msg": {
      "gitDirectory": "../.git",
      "types": [...]
```